### PR TITLE
fix: resolve 500 error caused by missing short ID display on redirect…

### DIFF
--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -29,7 +29,7 @@ const getShortUrlInfo = async (id: string) => {
 
   const shortUrlInfo = axiosResp.data as ReqUrlPreviewInfo;
   // Put the data into the cache.
-  cache.put(shortUrlInfo.id, shortUrlInfo);
+  if (shortUrlInfo) cache.put(shortUrlInfo.id, shortUrlInfo);
   return shortUrlInfo;
 };
 


### PR DESCRIPTION
… page

Adjust to not put the data into the cache if there is no data when querying from the database.