### PR TITLE
fix: Vercel build dependency caching issue fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@next/font": "13.1.6",
@@ -42,7 +43,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.8.4",
-    "prisma": "^4.10.1",
+    "prisma": "^4.13.0",
     "sass": "^1.58.3",
     "typescript": "^4.9.5"
   }


### PR DESCRIPTION
update prisma version.
add a custom postinstall script.